### PR TITLE
tr_array: fix use after free error after mbed_trace_free() is called

### DIFF
--- a/source/mbed_trace.c
+++ b/source/mbed_trace.c
@@ -202,6 +202,7 @@ void mbed_trace_free(void)
     m_trace.line_length = DEFAULT_TRACE_LINE_LENGTH;
     m_trace.tmp_data = 0;
     m_trace.tmp_data_length = DEFAULT_TRACE_TMP_LINE_LEN;
+    m_trace.tmp_data_ptr = 0;
     m_trace.prefix_f = 0;
     m_trace.suffix_f = 0;
     m_trace.printf  = mbed_trace_default_print;


### PR DESCRIPTION
If one called mbed_trace_free() but continued using the trace (which
is a supported use case), the already freed tmp_data buffer was used
by tr_array().

This was spotted by Valgrind on some unit tests which do enable the
trace only temporarily for some of the tests.

Error being fixed in this PR:
```
--8<--8<--8<---
==5865== Invalid write of size 1
==5865==    at 0x2639BB: mbed_trace_array (mbed_trace.c:569)
<...>
==5865==  Address 0x5dc79d0 is 0 bytes inside a block of size 128 free'd
==5865==    at 0x4C32D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==5865==    by 0x262723: mbed_trace_free (mbed_trace.c:192)
<...>
==5865==  Block was alloc'd at
==5865==    at 0x4C31B0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==5865==    by 0x262548: mbed_trace_init (mbed_trace.c:162)
<...>
```