### PR TITLE
mbed_trace_print_function_set accepts variable length arguments

### DIFF
--- a/mbed-trace/mbed_trace.h
+++ b/mbed-trace/mbed_trace.h
@@ -245,7 +245,7 @@ void mbed_trace_suffix_function_set(char *(*suffix_f)(void));
  * but with this you can write own print function,
  * for e.g. to other IO device.
  */
-void mbed_trace_print_function_set(void (*print_f)(const char *));
+void mbed_trace_print_function_set(void (*print_f)(const char *fmt, ...));
 /**
  * Set trace print function for tr_cmdline()
  */

--- a/source/mbed_trace.c
+++ b/source/mbed_trace.c
@@ -252,7 +252,7 @@ void mbed_trace_suffix_function_set(char *(*suffix_f)(void))
 {
     m_trace.suffix_f = suffix_f;
 }
-void mbed_trace_print_function_set(void (*printf)(const char *))
+void mbed_trace_print_function_set(void (*printf)(const char *fmt, ...))
 {
     m_trace.printf = printf;
 }


### PR DESCRIPTION
Hello team, 
I'm begineer in embed systems and study Mbed OS recently. 

I'd like to redirect mbed-trace output to a file and came up with using `mbed_trace_print_function_set`. My custom print function would wrapped `fprintf` and receive variable length arguments like `printf` and `fprintf`.

However, in my understanding, `mbed_trace_print_function_set` accepts only one char arugument so that I couldn't pass multiple arguments including format string and values.

I hope `mbed_trace_print_function_set` will change to accept variable length arguments.

Best regards